### PR TITLE
Groovy documentation

### DIFF
--- a/config.json
+++ b/config.json
@@ -21,7 +21,7 @@
 
   ],
   "ignored": [
-
+    "docs"
   ],
   "foregone": [
 

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,0 +1,14 @@
+[Groovy](http://www.groovy-lang.org/), initially released in 2007, is a dynamic object-oriented programming language based on Java.
+
+Groovy offers flexible and loosely typed syntax compared to Java, but still compiles down to [Java Virtual Machine](https://en.wikipedia.org/wiki/Java_virtual_machine) (JVM) [bytecode](https://en.wikipedia.org/wiki/Bytecode) and is fully interoperable with existing Java programs and libraries. 
+
+Some of Groovy's features include:
+  1. String interpolation, allowing static strings to include references to dynamic variables through the use of GStrings.
+  2. Closures, allowing code to be written a ran at a different time.
+  3. Flexible syntax, with semicolons, dots, and parentheses being optional in many cases.
+  4. Built in XML & JSON parsing.
+  5. [Metaprogramming](https://en.wikipedia.org/wiki/Metaprogramming).
+
+Groovy can also be used as a scripting language, similar to Python, allowing Groovy code to be executed without the need to be precompiled to class files first.
+
+While it can be used with any existing Java framework, the [Grails Framework](https://grails.org/) provides an alternative methodology for writing JVM based web applications in Groovy.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,3 +1,17 @@
 ### Installation
 
+#### Installing Java
+
+In order to work with Groovy, you will also need Java. The instructions for setting up Java can be found on [Oracle](https://docs.oracle.com/javase/8/docs/technotes/guides/install/install_overview.html), but you may also want to look at the installation instructions found on the [Java Exercism](http://exercism.io/languages/java) page
+
+#### Installing Groovy
+
 Detailed installation instructions for Groovy can be found at [http://www.groovy-lang.org/install.html](http://www.groovy-lang.org/install.html).
+
+#### Install an IDE
+
+It is recommended to use an IDE for working with your Groovy exercises. It will provide code assistance, automatic compilation, and a GUI for running the tests. 
+
+The community version of IntelliJ IDEA offers all the tooling you will need. Download and installation instructions can be found [here](https://www.jetbrains.com/idea/).
+
+

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,0 +1,3 @@
+### Installation
+
+Detailed installation instructions for Groovy can be found at [http://www.groovy-lang.org/install.html](http://www.groovy-lang.org/install.html).

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,0 +1,8 @@
+Interested in getting started with Groovy, or learning more while you work on exercises? 
+
+Check out some of these resources:
+* [Groovy Documentation](http://www.groovy-lang.org/documentation.html), By Dierk König, Paul King, Guillaume Laforge, Hamlet D'Arcy, Cédric Champeau, Erik Pragt, and Jon Skeet
+* [Groovy In Action](https://www.manning.com/books/groovy-in-action-second-edition)
+* [Making Java Groovy](https://www.manning.com/books/making-java-groovy), by Ken Kousen
+* [StackOverflow](http://stackoverflow.com/tags/groovy)
+* [Groovy Puzzlers](https://www.youtube.com/watch?v=GfIhxi7L6R0&list=PLwxhnQ2Qv3xuE4JEKBpyE2AbbM_7G0EN1&index=17), by Noam Tenne

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,0 +1,30 @@
+## The Groovy Language
+
+* [Learn Groovy](http://www.groovy-lang.org/learn.html)
+* [Groovy Documentation](http://www.groovy-lang.org/documentation.html)
+
+## Unit Testing
+
+* [Spock](http://spockframework.github.io/spock/docs/1.0/index.html), Groovy based testing framework.
+* [JUnit](http://junit.org/), the de-facto standard for Java based testing.
+
+## Frameworks
+
+* [Grails](https://grails.org/)
+* [Spring](https://spring.io/)
+
+## IDEs
+
+* [IntelliJ IDEA](https://www.jetbrains.com/idea/)
+* [Eclipse](https://eclipse.org/), with an additional plugin for Groovy language support.
+
+## Build Tools
+
+* [Gradle Docs](http://gradle.org/), an automated build tool, written in Groovy
+* [Apache Maven](https://maven.apache.org/)
+* [Gant](https://gant.github.io/)
+
+## Collaboration
+
+* [Groovy Community](http://www.groovy-lang.org/community.html)
+

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -5,8 +5,8 @@
 
 ## Unit Testing
 
-* [Spock](http://spockframework.github.io/spock/docs/1.0/index.html), Groovy based testing framework.
 * [JUnit](http://junit.org/), the de-facto standard for Java based testing.
+* [Spock](http://spockframework.github.io/spock/docs/1.0/index.html), Groovy based testing framework.
 
 ## Frameworks
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -24,6 +24,10 @@ unchanged: 0, updated: 0, new: 1
 
 4) IntelliJ will then create a new project structure in the editor for your exercise.
 
+5) Depending on how much of the IDE you have configured before, you will likely need to add a Groovy SDK and a Java SDK (JDK 7+, ideally). These can be configured through the project/module settings by right clicking on the imported project. 
+
+6) You may also need to configure the location of the compiler output (exercism doesn't provide all IDE files since you could work the problems in a myriad of editors instead). This can be configured in the project settings as well. 
+
 ## Start the exercise
 
 1) Open the `README.md` file and carefully read the background for the assignment.

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,4 +1,6 @@
-1) In a Command Prompt or Terminal, fetch the first exercise.
+## Fetch the exercise
+
+In a Command Prompt or Terminal, fetch the first exercise.
 
 ```
 C:\Users\You>exercism fetch groovy
@@ -12,21 +14,25 @@ groovy (Hello World) Path\To\Your\Exercism\groovy\hello-world
 unchanged: 0, updated: 0, new: 1
 ```
 
-2) Start IntelliJ IDEA. In the "Welcome to IntelliJ IDEA" window, click the "Open" option.
+## Import the exercise
 
-3) Navigate to the "Path\To\Your\Exercism\groovy\THIS_EXERCISE" folder.  Make sure you've selected the root directory of the exercise. Click "OK".
+1) Start IntelliJ IDEA. In the "Welcome to IntelliJ IDEA" window, click the "Open" option.
 
-4) Follow the dialog for creating the project from existing external sources.
+2) Navigate to the "Path\To\Your\Exercism\groovy\THIS_EXERCISE" folder.  Make sure you've selected the root directory of the exercise. Click "OK".
 
-5) IntelliJ will then create a new project structure in the editor for your exercise.
+3) Follow the dialog for creating the project from existing external sources.
 
-6) Open the `README.md` file and carefully read the background for the assignment.
+4) IntelliJ will then create a new project structure in the editor for your exercise.
 
-7) Start by running the test suite: In the "Project" view, right-click on the test file (`hello-world\HelloWorldTest.groovy`), select "Run", then pick the "EtlTest" that has a JUnit icon to the left of it (red and green arrows).
+## Start the exercise
 
-8) The tests are designed to fail at the beginning. Each exercise will expect you to update the associated groovy file (named the same as the test without the ````Tests```` suffix in the filename.
+1) Open the `README.md` file and carefully read the background for the assignment.
 
-9) To skip a test, you can add the @Ignore annotation a test method:
+2) Start by running the test suite: In the "Project" view, right-click on the test file (`hello-world\HelloWorldTest.groovy`), select "Run", then pick the "HelloWorldTest" that has a JUnit icon to the left of it (red and green arrows).
+
+3) The tests are designed to fail at the beginning. Each exercise will expect you to update the associated groovy file (named the same as the test without the ````Tests```` suffix in the filename.
+
+4) To skip a test, you can add the @Ignore annotation a test method:
 
 ````
   //This test will run.
@@ -45,4 +51,4 @@ unchanged: 0, updated: 0, new: 1
 
 Alternatively, you can simply comment out an entire method to have it removed from compilation and being included in test output.
 
-10) Update the main Groovy code and re-run the tests until they pass.
+5) Update the main Groovy code and re-run the tests until they pass.

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,0 +1,48 @@
+1) In a Command Prompt or Terminal, fetch the first exercise.
+
+```
+C:\Users\You>exercism fetch groovy
+
+Not Submitted:       1 problem
+groovy (Hello World) Path\To\Your\Exercism\groovy\hello-world
+
+New:                 1 problem
+groovy (Hello World) Path\To\Your\Exercism\groovy\hello-world
+
+unchanged: 0, updated: 0, new: 1
+```
+
+2) Start IntelliJ IDEA. In the "Welcome to IntelliJ IDEA" window, click the "Open" option.
+
+3) Navigate to the "Path\To\Your\Exercism\groovy\THIS_EXERCISE" folder.  Make sure you've selected the root directory of the exercise. Click "OK".
+
+4) Follow the dialog for creating the project from existing external sources.
+
+5) IntelliJ will then create a new project structure in the editor for your exercise.
+
+6) Open the `README.md` file and carefully read the background for the assignment.
+
+7) Start by running the test suite: In the "Project" view, right-click on the test file (`hello-world\HelloWorldTest.groovy`), select "Run", then pick the "EtlTest" that has a JUnit icon to the left of it (red and green arrows).
+
+8) The tests are designed to fail at the beginning. Each exercise will expect you to update the associated groovy file (named the same as the test without the ````Tests```` suffix in the filename.
+
+9) To skip a test, you can add the @Ignore annotation a test method:
+
+````
+  //This test will run.
+  @Test
+  void testNoName() {
+    assertTrue new HelloWorld().hello() == 'Hello, World!'
+  }
+
+  //this test will be skipped.
+  @Test
+  @Ignore
+  void testSampleName() {
+    assertTrue new HelloWorld().hello('Alice') == 'Hello, Alice!'
+  }
+````
+
+Alternatively, you can simply comment out an entire method to have it removed from compilation and being included in test output.
+
+10) Update the main Groovy code and re-run the tests until they pass.


### PR DESCRIPTION
Includes all necessary markdown to flesh out the Groovy language exercism docs.

Used the existing documentation for Elixir for reference, but splashed into the Java docs since Groovy requires it as an installation dependency. 
