### PR TITLE
Simplify Raindrops tests

### DIFF
--- a/exercises/raindrops/RaindropsTest.groovy
+++ b/exercises/raindrops/RaindropsTest.groovy
@@ -1,84 +1,17 @@
-import org.junit.Test
-import static org.junit.Assert.assertEquals
-
-class RaindropsTest {
-  @Test
-  void test1() {
-    assertEquals '1', new Raindrops().convert(1)
-  }
-
-  @Test
-  void test3() {
-    assertEquals 'Pling', new Raindrops().convert(3)
-  }
-
-  @Test
-  void test5() {
-    assertEquals 'Plang', new Raindrops().convert(5)
-  }
-
-  @Test
-  void test6() {
-    assertEquals 'Pling', new Raindrops().convert(6)
-  }
-
-  @Test
-  void test7() {
-    assertEquals 'Plong', new Raindrops().convert(7)
-  }
-
-  @Test
-  void test9() {
-    assertEquals 'Pling', new Raindrops().convert(9)
-  }
-
-  @Test
-  void test10() {
-    assertEquals 'Plang', new Raindrops().convert(10)
-  }
-
-  @Test
-  void test14() {
-    assertEquals 'Plong', new Raindrops().convert(14)
-  }
-
-  @Test
-  void test15() {
-    assertEquals 'PlingPlang', new Raindrops().convert(15)
-  }
-
-  @Test
-  void test21() {
-    assertEquals 'PlingPlong', new Raindrops().convert(21)
-  }
-
-  @Test
-  void test25() {
-    assertEquals 'Plang', new Raindrops().convert(25)
-  }
-
-  @Test
-  void test35() {
-    assertEquals 'PlangPlong', new Raindrops().convert(35)
-  }
-
-  @Test
-  void test49() {
-    assertEquals 'Plong', new Raindrops().convert(49)
-  }
-
-  @Test
-  void test52() {
-    assertEquals '52', new Raindrops().convert(52)
-  }
-
-  @Test
-  void test105() {
-    assertEquals 'PlingPlangPlong', new Raindrops().convert(105)
-  }
-
-  @Test
-  void test12121() {
-    assertEquals '12121', new Raindrops().convert(12121)
-  }
-}
+def raindrops = new Raindrops()
+assert raindrops.convert(1)     == '1'
+assert raindrops.convert(3)     == 'Pling'
+assert raindrops.convert(5)     == 'Plang'
+assert raindrops.convert(6)     == 'Pling'
+assert raindrops.convert(7)     == 'Plong'
+assert raindrops.convert(9)     == 'Pling'
+assert raindrops.convert(10)    == 'Plang'
+assert raindrops.convert(14)    == 'Plong'
+assert raindrops.convert(15)    == 'PlingPlang'
+assert raindrops.convert(21)    == 'PlingPlong'
+assert raindrops.convert(25)    == 'Plang'
+assert raindrops.convert(35)    == 'PlangPlong'
+assert raindrops.convert(49)    == 'Plong'
+assert raindrops.convert(52)    == '52'
+assert raindrops.convert(105)   == 'PlingPlangPlong'
+assert raindrops.convert(12121) == '12121'


### PR DESCRIPTION
By using simple Groovy assertions, we

- remove references to JUnit, which may confuse non-Java folk
- make the tests fit onto a single page, improving readability
- use Groovy's native power `assert`, making the tests more idiomatic
- remove the need to comment/ignore tests to practice TDD
  (the first test to fail outputs and halts)

But the primary motivator for me was to make the output clearer.

The second failure under JUnit tests reads something like:

```
] groovy RaindropsTest.groovy
JUnit 4 Runner, Tests: 16, Failures: 13, Time: 59
Test Failure: test105(RaindropsTest)
org.junit.ComparisonFailure: expected:<[PlingPlangPlong]> but was:<[105]>
    at org.junit.Assert.assertEquals(Assert.java:115)
    at org.junit.Assert.assertEquals(Assert.java:144)
```
...several dozen stacktrace lines, which tend to scroll.

Power assert outputs:

```
] groovy RaindropsTest.groovy
Caught: Assertion failed:

assert raindrops.convert(3)     == 'Pling'
       |         |              |
       |         3              false
       Raindrops@c267ef4

Assertion failed:

assert raindrops.convert(3)     == 'Pling'
       |         |              |
       |         3              false
       Raindrops@c267ef4

        at RaindropsTest.run(RaindropsTest.groovy:3)
]
```

Which does repeat once for the catch, but seems to me to read
nicer.