### PR TITLE
Make tests executable

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -7,6 +7,12 @@ Run the tests by executing the test script.
 $ groovy ./HelloWorldSpec.groovy
 ```
 
+The test files should also have the execution bit set.  In most environments, you should also be able to execute them directly.
+
+```
+$ ./HelloWorldSpec.groovy
+```
+
 After the first test(s) pass, continue by commenting out or removing the `@Ignore` annotations prepending other tests.
 
 When all tests pass, congratulations!

--- a/exercises/difference-of-squares/SquaresSpec.groovy
+++ b/exercises/difference-of-squares/SquaresSpec.groovy
@@ -1,3 +1,4 @@
+#!/usr/bin/env groovy
 @Grab('org.spockframework:spock-core:1.0-groovy-2.4')
 import spock.lang.*
 

--- a/exercises/gigasecond/GigasecondSpec.groovy
+++ b/exercises/gigasecond/GigasecondSpec.groovy
@@ -1,3 +1,4 @@
+#!/usr/bin/env groovy
 @Grab('org.spockframework:spock-core:1.0-groovy-2.4')
 import spock.lang.*
 import static java.util.Calendar.*

--- a/exercises/hamming/HammingSpec.groovy
+++ b/exercises/hamming/HammingSpec.groovy
@@ -1,3 +1,4 @@
+#!/usr/bin/env groovy
 @Grab('org.spockframework:spock-core:1.0-groovy-2.4')
 import spock.lang.*
 

--- a/exercises/hello-world/HelloWorldSpec.groovy
+++ b/exercises/hello-world/HelloWorldSpec.groovy
@@ -1,3 +1,4 @@
+#!/usr/bin/env groovy
 @Grab('org.spockframework:spock-core:1.0-groovy-2.4')
 import spock.lang.*
 

--- a/exercises/phone-number/PhoneNumberSpec.groovy
+++ b/exercises/phone-number/PhoneNumberSpec.groovy
@@ -1,3 +1,4 @@
+#!/usr/bin/env groovy
 @Grab('org.spockframework:spock-core:1.0-groovy-2.4')
 import spock.lang.*
 

--- a/exercises/raindrops/RaindropsSpec.groovy
+++ b/exercises/raindrops/RaindropsSpec.groovy
@@ -1,3 +1,4 @@
+#!/usr/bin/env groovy
 @Grab('org.spockframework:spock-core:1.0-groovy-2.4')
 import spock.lang.*
 

--- a/exercises/rna-transcription/ComplementSpec.groovy
+++ b/exercises/rna-transcription/ComplementSpec.groovy
@@ -1,3 +1,4 @@
+#!/usr/bin/env groovy
 @Grab('org.spockframework:spock-core:1.0-groovy-2.4')
 import spock.lang.*
 


### PR DESCRIPTION
I've been starting to look at the SETUP.md for xgroovy and comparing it with other language implementations, with a mind to seeing how we might make things a little better for folks.

I noticed that the xruby SETUP.md mentions that tests may be checked in as executables, so learners can simply execute the tests as file/scripts.

This commit sets the execuable bit for user and group in Git, and adds a shebang to, files that have been translated to Spock Specifications.